### PR TITLE
Prefix Notation to Tree 

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,77 +1,35 @@
 #include<iostream>
 #include "tokenizer.hpp"
-#include "convert.hpp"
+#include "tree.hpp"
 
 int main(){
     std::string str;
     std::cout << "ENTER: ";
     std::getline(std::cin, str);
 
-    removeSpace(str);
-    Token_t t[100];
-    float num[100];
-    float coeff[100];
-    char var[100];
-
-    tokenize(t, num, coeff, var, str);
-
+    //removeSpace(str);
+    Token *t;
+    
+    tokenize(t, str);
     int i = 0;
-    while(t[i] != END)
-        printTok(t[i++]);
+    while(t[i].t != END)
+        printTok(t[i++].t);
+    Node *root = NULL;
+    i = 0;
     
-    //reprint it
-    i = 0;
-    int j = 0, k = 0, l = 0;
-    while(t[i] != END){
-        if(t[i] == DIGIT){
-            std::cout << num[j++] << ' ';
-        }
-        else if(t[i] == COEFFICIENT)
-            std::cout << coeff[k++];
-        else if(t[i] == VAR)
-            std::cout << var[l++] << ' ';
-        else
-            printTok(t[i]);
-        i++;
-    }
+    root = createNode(t[i++]);
+    preToTree(t, &i, &(root->left));
+    preToTree(t, &i, &(root->right));
 
     std::cout << std::endl;
-    inToPost(t, num, coeff, t);
+    preorder(root);
+    std::cout << std::endl;
+    inorder(root);
+    std::cout << std::endl;
+    postorder(root);
 
-    i = 0;
-    j = 0, k = 0, l = 0;
-    while(t[i] != END){
-        if(t[i] == DIGIT){
-            std::cout << num[j++] << ' ';
-        }
-        else if(t[i] == COEFFICIENT)
-            std::cout << coeff[k++];
-        else if(t[i] == VAR)
-            std::cout << var[l++] << ' ';
-        else
-            printTok(t[i]);
-        i++;
-    }
+    //inorder(root);
+
+
     
-    std::cout << std::endl;
-
-    postToIn(t, num, coeff, t);
-
-    i = 0;
-    j = 0, k = 0, l = 0;
-    while(t[i] != END){
-        if(t[i] == DIGIT){
-            std::cout << num[j++] << ' ';
-        }
-        else if(t[i] == COEFFICIENT)
-            std::cout << coeff[k++];
-        else if(t[i] == VAR)
-            std::cout << var[l++] << ' ';
-        else
-            printTok(t[i]);
-        i++;
-    }
-
-    std::cout << std::endl;
-    return 0;
 }

--- a/tokenizer.hpp
+++ b/tokenizer.hpp
@@ -24,6 +24,18 @@ typedef struct tok{
     char var;
 } Token;
 
+int isTokOperator(Token_t t){
+    switch(t){
+        case ADD:
+        case SUBTRACT:
+        case DIVIDE:
+        case MULTIPLY:
+        case POW:
+        case MOD:
+            return 1;
+    }
+    return 0;
+}
 
 void removeSpace(std::string str){
     str.erase(std::remove(str.begin(), str.end(), ' '), str.end());

--- a/tree.hpp
+++ b/tree.hpp
@@ -12,19 +12,16 @@ typedef struct node{
     struct node* right;
 }Node;
 
-Node createNode(Token tok){
-    Node n;
-    n.tok = tok;
-    n.left = nullptr;
-    n.right = nullptr;
+Node* createNode(Token tok){
+    Node *n = (Node*) malloc(sizeof(Node));
+    n->tok = tok;
+    n->left = nullptr;
+    n->right = nullptr;
 
     return n;
 }
 
-void insertNode(Token tok, Node **n){
-    *n = (Node*) malloc(sizeof(Node));
-    **n = createNode(tok);
-}
+
 void preorder(Node *n){
     if(n == nullptr)
         return;
@@ -50,19 +47,21 @@ void postorder(Node* n){
 }
 
 //populate the tree based on operation
-void preToTree(Token **t, Node* root){
-    if((*t)->t == END)
+void preToTree(Token *t, int *curr, Node** root){
+    if(t[*curr].t == END)
         return;
-    if((*t)->t == DIGIT || (*t)->t == VAR){
-        insertNode(**t, &root);
-        (*t)++; //move to next token
+    if(t[*curr].t == DIGIT || t[*curr].t == VAR){
+        *root = createNode(t[*curr]);
+        (*curr)++;
         return;
     }
-    //not a digit, so must be operator
-    insertNode(**t, &root);
-    (*t)++; //move to next token
-    preToTree(t, root->left);
-    preToTree(t, root->right);
+    *root = createNode(t[*curr]);
+    (*curr)++;
+    preToTree(t, curr, &((*root)->left));
+    preToTree(t, curr, &((*root)->right));
+
 }
+
+
 
 #endif

--- a/tree.hpp
+++ b/tree.hpp
@@ -49,5 +49,20 @@ void postorder(Node* n){
     printTokLiteral(n->tok);
 }
 
+//populate the tree based on operation
+void preToTree(Token **t, Node* root){
+    if((*t)->t == END)
+        return;
+    if((*t)->t == DIGIT || (*t)->t == VAR){
+        insertNode(**t, &root);
+        (*t)++; //move to next token
+        return;
+    }
+    //not a digit, so must be operator
+    insertNode(**t, &root);
+    (*t)++; //move to next token
+    preToTree(t, root->left);
+    preToTree(t, root->right);
+}
 
 #endif

--- a/tree.hpp
+++ b/tree.hpp
@@ -12,6 +12,15 @@ typedef struct node{
     struct node* right;
 }Node;
 
+Node createNode(Token tok){
+    Node n;
+    n.tok = tok;
+    n.left = nullptr;
+    n.right = nullptr;
+
+    return n;
+}
+
 void preorder(Node *n){
     if(n == nullptr)
         return;

--- a/tree.hpp
+++ b/tree.hpp
@@ -21,6 +21,10 @@ Node createNode(Token tok){
     return n;
 }
 
+void insertNode(Token tok, Node **n){
+    *n = (Node*) malloc(sizeof(Node));
+    **n = createNode(tok);
+}
 void preorder(Node *n){
     if(n == nullptr)
         return;


### PR DESCRIPTION
Converts prefix notation to a tree that can be traversed. Make sure to use spaces when entering an expression in prefix notation
